### PR TITLE
Make script compatible with latest scenario player

### DIFF
--- a/summary_template.html
+++ b/summary_template.html
@@ -33,6 +33,10 @@
                             <td>{{ item.mean }}</td>
                         </tr>
                         <tr>
+                            <td>95%</td>
+                            <td>{{ item.p95 }}</td>
+                        </tr>
+                        <tr>
                             <td>Median</td>
                             <td>{{ item.median }}</td>
                         </tr>


### PR DESCRIPTION
This PR changes the logfile parsing to make use of the `runtime` durations that are now logged by the scenario player. In order to work, it relies on https://github.com/raiden-network/scenario-player/pull/535
This fixes #2 

Also added here:
- support for `gzip` logfiles
- parsing of node logs (based on SP log file path and `run_number` globbing)
- grouping of `TransferTask`s based on "number of hops" (number of nodes that logged anything about a certain `"identifier"`)
- 95% percentile calculation (95% of $TASK took up to `X` seconds)
- short stats file output (as json)

Example of the stats output
```
[
  {
    "name": "AssertPFSHistoryTask",
    "min": "0.08170568398782052",
    "max": "0.25221617898205295",
    "mean": "0.16696093148493674",
    "median": "0.16696093148493674",
    "p95": "0.24369065423234132",
    "stdev": "0.08525524749711622",
    "count": "2"
  },
  {
    "name": "AssertPFSIoUTask",
    "min": "0.036272828991059214",
    "max": "0.075187634996837",
    "mean": "0.06167850532801822",
    "median": "0.07357505199615844",
    "p95": "0.07502637669676915",
    "stdev": "0.017976584743998852",
    "count": "3"
  },
  {
    "name": "AssertSumTask",
    "min": "0.008320105000166222",
    "max": "0.02260726600070484",
    "mean": "0.018907201002002695",
    "median": "0.021090748996357433",
    "p95": "0.022234848704829346",
    "stdev": "0.004828744253304528",
    "count": "10"
  },
  {
    "name": "AssertTask",
    "min": "0.0061689809954259545",
    "max": "0.0387127100257203",
    "mean": "0.020471988928665478",
    "median": "0.021400583995273337",
    "p95": "0.034873722813790656",
    "stdev": "0.008964597787803718",
    "count": "13"
  },
  {
    "name": "DepositTask",
    "min": "169.94283221600926",
    "max": "282.9213742050051",
    "mean": "202.25505455643204",
    "median": "194.7598177990003",
    "p95": "256.92327950849716",
    "stdev": "34.12903224421601",
    "count": "7"
  },
  {
    "name": "OpenChannelTask",
    "min": "288.34401160199195",
    "max": "395.3498867250164",
    "mean": "310.91735109640285",
    "median": "289.7990063310135",
    "p95": "374.7451263486117",
    "stdev": "42.23892166219813",
    "count": "5"
  },
  {
    "name": "ParallelTask",
    "min": "0.007070523017318919",
    "max": "395.36732449999545",
    "mean": "128.84867062874764",
    "median": "84.9933014720009",
    "p95": "356.0161629194902",
    "stdev": "143.92740577659748",
    "count": "8"
  },
  {
    "name": "SerialTask",
    "min": "0.08346325400634669",
    "max": "450.9010333849874",
    "mean": "164.04602273870327",
    "median": "100.06530145701254",
    "p95": "330.24622278500453",
    "stdev": "130.31306354508865",
    "count": "17"
  },
  {
    "name": "StoreChannelInfoTask",
    "min": "0.006642688007559627",
    "max": "0.006642688007559627",
    "mean": "0.006642688007559627",
    "median": "0.006642688007559627",
    "p95": "0.006642688007559627",
    "stdev": "0.0",
    "count": "1"
  },
  {
    "name": "TransferTask(1 hops)",
    "min": "0.0825375379936304",
    "max": "0.0825375379936304",
    "mean": "0.0825375379936304",
    "median": "0.0825375379936304",
    "p95": "0.0825375379936304",
    "stdev": "0.0",
    "count": "1"
  },
  {
    "name": "TransferTask(3 hops)",
    "min": "3.3409499099943787",
    "max": "10.798768845997984",
    "mean": "4.7009315807916",
    "median": "4.417496285488596",
    "p95": "6.469964420235192",
    "stdev": "1.1327043911686205",
    "count": "144"
  },
  {
    "name": "TransferTask(4 hops)",
    "min": "9.051328124012798",
    "max": "9.051328124012798",
    "mean": "9.051328124012798",
    "median": "9.051328124012798",
    "p95": "9.051328124012798",
    "stdev": "0.0",
    "count": "1"
  },
  {
    "name": "WithdrawTask",
    "min": "97.50521050899988",
    "max": "97.50521050899988",
    "mean": "97.50521050899988",
    "median": "97.50521050899988",
    "p95": "97.50521050899988",
    "stdev": "0.0",
    "count": "1"
  }
]
```