### PR TITLE
Add prometheus file export

### DIFF
--- a/prometheus.py
+++ b/prometheus.py
@@ -1,0 +1,27 @@
+from itertools import groupby
+from typing import Any, Dict, List
+
+from prometheus_client import CollectorRegistry, Summary, write_to_textfile
+
+
+def parse_filled_rows(
+    filled_rows: Dict[str, List[Any]], scenario_name: str, target_file: str
+) -> None:
+    registry = CollectorRegistry()
+    summary = Summary(
+        "task_duration",
+        "The duration summary of a certain task",
+        labelnames=["scenario", "task", "nodes_involved"],
+        unit="sec",
+        registry=registry,
+        namespace="scenario_player",
+    )
+    k = lambda r: r.task_type
+    for key, group in groupby(sorted(filled_rows["csv_rows"], key=k), key=k):
+        task = key.split("(", 1)[0]
+        group = list(group)
+        for entry in group:
+            summary.labels(
+                scenario=scenario_name, task=task, nodes_involved=entry.nodes_involved
+            ).observe(entry.duration)
+    write_to_textfile(target_file, registry)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ six==1.12.0
 traitlets==4.3.2
 urllib3==1.25.3
 pyyaml
+prometheus_client


### PR DESCRIPTION
This adds a prometheus node_exporter compatible file dump with Task performance numbers.

By the default the instrumentation is written to `/tmp/nodeexporter.txt`, which can be overwritten by setting the `PROMETHEUS_NODE_EXPORTER_PATH` environment variable.