### PR TITLE
Update jinja2 (major version)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ chardet==3.0.4
 decorator==4.4.0
 idna==2.8
 ipython-genutils==0.2.0
-Jinja2==2.11.3
+jinja2==3.1.1
 jsonschema==3.0.1
 jupyter-core==4.4.0
 nbformat==4.4.0


### PR DESCRIPTION
The old version was causing the error
`ImportError: cannot import name 'soft_unicode' from 'markupsafe'`
because it was not pinned to a specific markupsafe version, jinja2 did
not specify an upper bound and the latest markupsafe removed
`soft_unicode`, which is used by jinja2<3.1. See also
https://github.com/pallets/markupsafe/issues/286.